### PR TITLE
Expose a non-pinned renovate option

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,25 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":combinePatchMinorReleases",
-    ":dependencyDashboard",
     ":pinAllExceptPeerDependencies",
-    ":separateMajorReleases",
-    "config:base",
-    "group:monorepos",
-
-    "github>bitwarden/renovate-config:pin-actions"
-  ],
-  "commitMessagePrefix": "[deps]:",
-  "commitMessageTopic": "{{depName}}",
-  "prConcurrentLimit": 0,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "every 2nd week starting on the 2 week of the year before 4am on Monday"
-    ]
-  },
-  "schedule": [
-    "every 2nd week starting on the 2 week of the year before 4am on Monday"
+    "github>bitwarden/renovate-config:non-pinned"
   ]
 }

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":combinePatchMinorReleases",
+    ":dependencyDashboard",
+    ":separateMajorReleases",
+    "config:base",
+    "group:monorepos",
+
+    "github>bitwarden/renovate-config:pin-actions"
+  ],
+  "commitMessagePrefix": "[deps]:",
+  "commitMessageTopic": "{{depName}}",
+  "prConcurrentLimit": 0,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "every 2nd week starting on the 2 week of the year before 4am on Monday"
+    ]
+  },
+  "schedule": [
+    "every 2nd week starting on the 2 week of the year before 4am on Monday"
+  ]
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

- 🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

SDK needs a configuration that does not pin dependencies. Since we want to share the other presets, the default preset now inherits the non-pinned config.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
