### PR TITLE
Preserve SemVer for NVM updates

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -6,7 +6,6 @@
     ":separateMajorReleases",
     "config:base",
     "group:monorepos",
-
     "github>bitwarden/renovate-config:pin-actions"
   ],
   "commitMessagePrefix": "[deps]:",

--- a/pin-actions.json
+++ b/pin-actions.json
@@ -9,6 +9,10 @@
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["helm/chart-releaser-action"],
       "allowedVersions": "<=1.5.0"
+    },
+    {
+      "matchManagers": ["nvm"],
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

Internal change. See https://github.com/bitwarden/contributing-docs/pull/371.

## 📔 Objective

NVM updates will currently obey `:pinAllExceptPeerDependencies` given our setup here and its use in Node-oriented repos. To avoid unnecessary upkeep, we can tell Renovate to preserve semantic versioning so this will just end up as `v20` for example.

We considered setting global rules on maximum versions for Node and NPM generally, but this should be inside the repos' `package.json` `engines` configurations e.g. https://github.com/bitwarden/clients/blob/main/package.json#L226-L229.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
