### PR TITLE
Explore if setting branchConcurrentLimit resolves bug

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -11,6 +11,7 @@
   "commitMessagePrefix": "[deps]:",
   "commitMessageTopic": "{{depName}}",
   "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Renovate isn't opening all the PRs that we expect. Explore if we can explicitly set `branchConcurrentLimit` to 0 to force it to open as many PRs as possible.

Per the documentation https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit it should inherit the value from `prConcurrentLimit` but this doesn't seem to be the case as the logs mentions branch limits.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
