### PR TITLE
Disable prHourlyLimit

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -11,6 +11,7 @@
   "commitMessagePrefix": "[deps]:",
   "commitMessageTopic": "{{depName}}",
   "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "branchConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

https://github.com/bitwarden/renovate-config/pull/12 resolved one rate limiting aspect, however we're now limited by how many PRs it opens during a single hour.

```DEBUG: Calculated maximum branches remaining this run: 2```

https://docs.renovatebot.com/configuration-options/#prhourlylimit

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
