### PR TITLE
PM-13335 - Pin Rust version and introduce Renovate

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -25,5 +25,30 @@
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "additionalReviewers": ["team:team-appsec"]
-  }
+  },
+  "customDatasources": {
+    "rust-nightly": {
+      "defaultRegistryUrlTemplate": "https://renovate-rust-nightly.phi-ag.workers.dev/"
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "depNameTemplate": "rust",
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\""
+      ],
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "depNameTemplate": "rust-nightly",
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
+      "matchStrings": ["nightly-channel\\s*=\\s*\"nightly-(?<currentValue>.+?)\"\\n"],
+      "versioningTemplate": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
+      "datasourceTemplate": "custom.rust-nightly"
+    }
+  ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13335

## 📔 Objective

Add Renovate managers so we can pin the Rust and Rust nightly toolchains in our workflows.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/5a51fafc-f94a-4874-a641-f3fff2f718f8)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
