### PR TITLE
[PM-15985] Add configuration for minimum release age

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -14,7 +14,6 @@
   "prHourlyLimit": 0,
   "branchConcurrentLimit": 0,
   "minimumReleaseAge": "7 days",
-  "internalChecksFilter": "strict",
   "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true,

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -13,6 +13,9 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "branchConcurrentLimit": 0,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15985

## 📔 Objective

Suppresses the creation of PRs for 7 days after the dependency release is stable, so that we can avoid introducing dependencies that may not have had time for security issues to be addressed.

The relevant config that was changed is:
- `minimumReleaseAge` - Documented [here](https://github.com/renovatebot/renovate/discussions/32829).
- `internalChecksFilter` - Documented [here](https://github.com/renovatebot/renovate/discussions/32829). This is recommended to be set to `strict` along with `minimumReleaseAge` to ensure that we don't bounce between release versions. This forces Renovate to strictly apply all internal checks before allowing an update.
- `prCreation` - Documented [here](https://docs.renovatebot.com/configuration-options/#prcreation).  Several [discussions](https://github.com/renovatebot/renovate/discussions/32829) on Renovate boards indicate that this is now best practice to include setting `prCreation` to be `not-pending` along with minimum release age configuration, in order to hold the PR from being created prematurely.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
