### PR TITLE
Send github-actions patch updates to Dependency Dashboard for approval

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,5 +3,13 @@
   "extends": [
     ":pinAllExceptPeerDependencies",
     "github>bitwarden/renovate-config:non-pinned"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "updateTypes": ["patch"],
+      "dependencyDashboardApproval": true,
+      "description": "Patch updates on approval dashboard"
+    }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -3,13 +3,5 @@
   "extends": [
     ":pinAllExceptPeerDependencies",
     "github>bitwarden/renovate-config:non-pinned"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "updateTypes": ["patch"],
-      "dependencyDashboardApproval": true,
-      "description": "Patch updates on approval dashboard"
-    }
   ]
 }

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -52,5 +52,13 @@
       "versioningTemplate": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
       "datasourceTemplate": "custom.rust-nightly"
     }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "updateTypes": ["patch"],
+      "dependencyDashboardApproval": true,
+      "description": "View patch updates on approval dashboard for GitHub Actions"
+    }
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-17933](https://bitwarden.atlassian.net/browse/PM-17933)

## 📔 Objective

We would like visibility of patch updates for `github-actions` patch updates, but not necessarily burden the teams with reviewing them all.

To try to accomplish this, we're going to send such updates through the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/#dependency-dashboard-approval-workflow) approval flow.

See https://github.com/bitwarden/clients/pull/13234 for corresponding PR in `clients` to do additional cleanup of the `github-action` dependency process.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
