### PR TITLE
[PM-20478] Remove not-pending status check

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -14,7 +14,6 @@
   "prHourlyLimit": 0,
   "branchConcurrentLimit": 0,
   "minimumReleaseAge": "7 days",
-  "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20476

## 📔 Objective

In https://github.com/bitwarden/renovate-config/issues/18, I added `"prCreation": "not-pending"`, based on the recommendation in [this](https://github.com/renovatebot/renovate/discussions/32829) discussion on the Renovate forums.  This appeared to be an undocumented requirement in order for the `minimumReleaseAge` to work.

However, we're now seeing behavior that PRs are not being created for dependencies that do meet the minimum release age.  After debugging the runs, it appears that this is because the `not-pending` check is preventing the creation of a PR due to the fact that we don't have _any_ commit checks.  After querying for branch status, we get this log message:

```
Successful checks are all internal renovate/ checks, so returning “pending” branch status
```

As this puts the branch in `pending`, our restriction to a `not-pending` status prevents the PR from being created.

⚠️ We will need to watch the first run to make sure that this has its intended effect and doesn't bypass the minimum release age.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
