### PR TITLE
Update default to send npm and nuget patch updates to dashboard

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -62,7 +62,7 @@
       ],
       "updateTypes": ["patch"],
       "dependencyDashboardApproval": true,
-      "description": "View patch updates on approval dashboard for cargo, github-actions, npm and nuget"
+      "description": "View patch updates on the dashboard for Cargo, GitHub Actions, NPM and NuGet"
     }
   ]
 }

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -55,12 +55,14 @@
   "packageRules": [
     {
       "matchManagers": [
+        "cargo",
         "github-actions",
-        "cargo"
+        "npm",
+        "nuget"
       ],
       "updateTypes": ["patch"],
       "dependencyDashboardApproval": true,
-      "description": "View patch updates on approval dashboard for GitHub Actions"
+      "description": "View patch updates on approval dashboard for cargo, github-actions, npm and nuget"
     }
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

`npm`: https://bitwarden.atlassian.net/browse/PM-17637
`nuget`: https://bitwarden.atlassian.net/browse/PM-17239

## 📔 Objective

This PR changes how we manage patch updates for `npm` and `nuget`.  It changes these package managers to, by default, not automatically open PRs for patch updates.

We do want to build in exceptions to this default behavior, which are captured in these related PRs:

`clients`: https://github.com/bitwarden/clients/pull/14655
`server`: https://github.com/bitwarden/server/pull/5775

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
