### PR TITLE
[PM-21260] Add ignored dependencies for npm and node

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -62,5 +62,9 @@
       "dependencyDashboardApproval": true,
       "description": "View patch updates on approval dashboard for GitHub Actions"
     }
+  ],
+  "ignoreDeps": [
+    "node",
+    "npm"
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21260

## 📔 Objective

We currently ignore `node` and `npm` (among others) [here](https://github.com/bitwarden/clients/blob/89ebca18853bcd673b3db93073063f488d96579a/.github/renovate.json5#L426).

For consistency, we'd like to move this to the default configuration so that other repositories using `npm` and `node` have the same configuration.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
