### PR TITLE
[BRE-758] Provide only security updates for GitHub Actions

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -27,6 +27,7 @@
     "labels": ["security"],
     "additionalReviewers": ["team:team-appsec"]
   },
+  "osvVulnerabilityAlerts": true,
   "customDatasources": {
     "rust-nightly": {
       "defaultRegistryUrlTemplate": "https://renovate-rust-nightly.phi-ag.workers.dev/"

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -59,6 +59,22 @@
       "enabled": false
     },
     {
+      "matchSourceUrls": [
+        "https://github.com/**"
+      ],
+      "prBodyDefinitions": {
+        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
+      },
+      "prBodyColumns": [
+        "Package",
+        "Type",
+        "Update",
+        "Change",
+        "Pending",
+        "OpenSSF"
+      ]
+    },
+    {
       "matchManagers": [
         "cargo",
         "npm",

--- a/non-pinned.json
+++ b/non-pinned.json
@@ -55,15 +55,18 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["github-actions"],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "cargo",
-        "github-actions",
         "npm",
         "nuget"
       ],
       "updateTypes": ["patch"],
       "dependencyDashboardApproval": true,
-      "description": "View patch updates on the dashboard for Cargo, GitHub Actions, NPM and NuGet"
+      "description": "View patch updates on the dashboard for Cargo, NPM and NuGet"
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-758

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Disable `github-actions` updates to allow only security updates to create automated PRs.
- Add OpenSSF badge for dependencies
- Enable [OSV](https://osv.dev/) vulnerability alerts

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
