### PR TITLE
Revert Actions change that was not reviewed

### DIFF
--- a/non-pinned.json
+++ b/non-pinned.json
@@ -27,7 +27,6 @@
     "labels": ["security"],
     "additionalReviewers": ["team:team-appsec"]
   },
-  "osvVulnerabilityAlerts": true,
   "customDatasources": {
     "rust-nightly": {
       "defaultRegistryUrlTemplate": "https://renovate-rust-nightly.phi-ag.workers.dev/"
@@ -55,34 +54,15 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "enabled": false
-    },
-    {
-      "matchSourceUrls": [
-        "https://github.com/**"
-      ],
-      "prBodyDefinitions": {
-        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
-      },
-      "prBodyColumns": [
-        "Package",
-        "Type",
-        "Update",
-        "Change",
-        "Pending",
-        "OpenSSF"
-      ]
-    },
-    {
       "matchManagers": [
         "cargo",
+        "github-actions",
         "npm",
         "nuget"
       ],
       "updateTypes": ["patch"],
       "dependencyDashboardApproval": true,
-      "description": "View patch updates on the dashboard for Cargo, NPM and NuGet"
+      "description": "View patch updates on the dashboard for Cargo, GitHub Actions, NPM and NuGet"
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## 🎟️ Tracking

Discussion with Renovate managers.

## 📔 Objective

A `CODEOWNERS` issue let a change in without review, and we need to discuss Actions PRs so reverting this for the moment.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
